### PR TITLE
Exclude Pending Txn Sources when Making Payment

### DIFF
--- a/src/block_chain/transactions.clj
+++ b/src/block_chain/transactions.clj
@@ -2,6 +2,7 @@
   (:require [block-chain.utils :refer :all]
             [block-chain.wallet :as wallet]
             [block-chain.queries :as q]
+            [clojure.set :refer [difference]]
             [block-chain.db :as db]
             [cheshire.core :as json]))
 
@@ -131,7 +132,8 @@
 (defn unsigned-payment
   ([from-address to-address amount db] (unsigned-payment from-address to-address amount db 0))
   ([from-address to-address amount db fee]
-   (let [output-pool (q/unspent-outputs from-address db)
+   (let [output-pool (difference (into #{} (q/unspent-outputs from-address db))
+                                 (q/outputs-spent-by-txn-pool db))
          sources (select-sources (+ amount fee) output-pool)
          txn (raw-txn amount to-address sources)]
      (-> txn


### PR DESCRIPTION
When we produce a payment from one address to another
we should avoid sourcing any inputs that are already
consumed by an input in the pending transaction pool.

Without accounting for this, generating 2 payments within
the timeframe of the same block would result in trying to
re-use the same inputs (since they appear unspent from
the perspective of the confirmed blocks) within that block.

This way an address can continue to make multiple payments
within the same block as long as they have enough funds
